### PR TITLE
DatabaseWrapper.check_constraints shouldn't do anything

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -436,3 +436,9 @@ class DatabaseWrapper(BasePGDatabaseWrapper):
             # Commit after setting the time zone (see #17062)
             if not self.get_autocommit():
                 self.connection.commit()
+
+    def check_constraints(self, table_names=None):
+        """
+        No constraints to check in Redsfhift.
+        """
+        pass


### PR DESCRIPTION
hey @shimizukawa, another fix to add :)

---

Original backtrace:
```
Traceback (most recent call last):
  File "./manage.py", line 32, in <module>
    execute_from_command_line(sys.argv)
  File "...django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "...django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "...django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "...django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "...django/core/management/commands/migrate.py", line 179, in handle
    created_models = self.sync_apps(connection, executor.loader.unmigrated_apps)
  File "...django/core/management/commands/migrate.py", line 365, in sync_apps
    hide_empty=True,
  File "...django/core/management/__init__.py", line 120, in call_command
    return command.execute(*args, **defaults)
  File "...django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "...django/core/management/commands/loaddata.py", line 60, in handle
    self.loaddata(fixture_labels)
  File "...django/core/management/commands/loaddata.py", line 96, in loaddata
    connection.check_constraints(table_names=table_names)
  File "...django/db/backends/postgresql_psycopg2/base.py", line 225, in check_constraints
    self.cursor().execute('SET CONSTRAINTS ALL IMMEDIATE')
  File "...django/db/backends/utils.py", line 79, in execute
    return super(CursorDebugWrapper, self).execute(sql, params)
  File "...django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "...django/db/utils.py", line 98, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "...django/db/backends/utils.py", line 62, in execute
    return self.cursor.execute(sql)
django.db.utils.NotSupportedError: Problem installing fixtures: SQL command "SET CONSTRAINTS ALL IMMEDIATE" not supported.
```