### PR TITLE
sequence_reset_sql() is not supported

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -41,6 +41,9 @@ class DatabaseOperations(BasePGDatabaseOperations):
         # unused
         return ""
 
+    def sequence_reset_sql(self, style, model_list):
+        # impossible with Redshift to reset a sequence
+        return []
 
 def _related_non_m2m_objects(old_field, new_field):
     # Filters out m2m objects from reverse relations.


### PR DESCRIPTION
hey @shimizukawa the following is very useful if you want to use fixtures. It avoids an issue when trying to reset the sequence for an `identity()` field (it's not supported by Redshift).