### PR TITLE
removed column level check constraint DDL generation

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -29,6 +29,7 @@ class DatabaseFeatures(BasePGDatabaseFeatures):
     can_return_id_from_insert = False
     can_return_ids_from_bulk_insert = False
     has_select_for_update = False
+    supports_column_check_constraints = False
 
 
 class DatabaseOperations(BasePGDatabaseOperations):
@@ -126,10 +127,6 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
                         str(int(m.group(1)) * self.multiply_varchar_length)),
                     definition)
 
-            # Check constraints can go on the column SQL here
-            db_params = field.db_parameters(connection=self.connection)
-            if db_params['check']:
-                definition += " CHECK (%s)" % db_params['check']
             # Autoincrement SQL (for backends with inline variant)
             col_type_suffix = field.db_type_suffix(connection=self.connection)
             if col_type_suffix:
@@ -459,6 +456,7 @@ redshift_data_types = {
     "BigAutoField": "bigint identity(1, 1)",
     "DateTimeField": "timestamp",
     "TextField": "varchar(max)",  # text must be varchar(max)
+    "PositiveIntegerField": ""
 }
 
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -127,6 +127,7 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
                         str(int(m.group(1)) * self.multiply_varchar_length)),
                     definition)
 
+            db_params = field.db_parameters(connection=self.connection)
             # Autoincrement SQL (for backends with inline variant)
             col_type_suffix = field.db_type_suffix(connection=self.connection)
             if col_type_suffix:
@@ -456,7 +457,6 @@ redshift_data_types = {
     "BigAutoField": "bigint identity(1, 1)",
     "DateTimeField": "timestamp",
     "TextField": "varchar(max)",  # text must be varchar(max)
-    "PositiveIntegerField": ""
 }
 
 


### PR DESCRIPTION
Redshift doesn't support column level check constraints, using a PositiveIntegerField throws an error. The db backend shouldn't generate DDL containing column level check constraints.