### PR TITLE
Support Django-1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DJANGO_VERSION=1.8.*
   - DJANGO_VERSION=1.9.*
   - DJANGO_VERSION=1.10.*
+  - DJANGO_VERSION=1.11.*
 matrix:
   exclude:
     - python: 3.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ VOLUME /app
 
 RUN pip install -U -r test-requires.txt tox
 
-CMD ["tox", "-e", "flake8,py{27,35}-django{17,18,19,110}"]
+CMD ["tox", "-e", "flake8,py{27,35}-django{17,18,19,110,111}"]
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Redshift database backend for Django
 This product is tested with:
 
 * python-2.7, 3.4, 3.5
-* django-1.7, 1.8, 1.9, 1.10
+* django-1.7, 1.8, 1.9, 1.10, 1.11
 
 
 Differences from postgres_psycopg2 backend
@@ -95,6 +95,7 @@ CHANGES
 0.7 (Unreleased)
 ----------------
 
+* Support Django-1.11
 
 0.6 (2016-12-15)
 ----------------

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -11,6 +11,12 @@ import logging
 
 import django
 from django.conf import settings
+try:
+    # Need for Django v1.11+
+    from django.db.backends.base.validation import BaseDatabaseValidation
+except ImportError:
+    # Need for older versions of Django < v1.11
+    from django.db.backends.postgresql_psycopg2.base import BaseDatabaseValidation
 from django.db.backends.postgresql_psycopg2.base import (
     DatabaseFeatures as BasePGDatabaseFeatures,
     DatabaseWrapper as BasePGDatabaseWrapper,
@@ -19,7 +25,6 @@ from django.db.backends.postgresql_psycopg2.base import (
     DatabaseClient,
     DatabaseCreation as BasePGDatabaseCreation,
     DatabaseIntrospection,
-    BaseDatabaseValidation,
 )
 
 logger = logging.getLogger('django.db.backends')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py{27,34,35}-django{17,18,19,110}
+envlist = flake8,py{27,34,35}-django{17,18,19,110,111}
 skipsdist = True
 
 [testenv]
@@ -8,6 +8,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
     -rtest-requires.txt
 setenv =
     DJANGO_SETTINGS_MODULE = settings


### PR DESCRIPTION
Simple change:
BaseDatabaseValidation now comes from django.db.backends.base.validation
Also added Django-1.11 to tox version set. All test pass

Would be great to release right away, as it is blocking move to Django 1.11