### PR TITLE
Redshift support time zones in time stamps from Sep, 2016

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Type mapping:
 
 * 'integer identity(1, 1)' for AutoField
 * 'bigint identity(1, 1)' for BigAutoField
-* 'timestamp' for DateTimeField
+* 'timestamp with time zone' for DateTimeField
 * 'varchar(max)' for TextField
 * 'varchar(32)' for UUIDField
 * Possibility to multiply VARCHAR length to support utf-8 string, using

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,6 @@ Stop using:
 
 * RETURNING (single insert and bulk insert)
 * SELECT FOR UPDATE
-* SET TIME ZONE
 * SET CONSTRAINTS
 * INDEX
 * DEFERRABLE INITIALLY DEFERRED
@@ -115,6 +114,7 @@ CHANGES
 * #18: Fix error on migration with django-1.9 or later that raises AttributeError
   of 'sql_create_table_unique'.
 * #24: Add UUIDField support. Thanks to Sindri Guðmundsson.
+* #23 Redshift support time zones in time stamps
 
 0.7 (2017-06-08)
 ----------------

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -499,7 +499,6 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
 redshift_data_types = {
     "AutoField": "integer identity(1, 1)",
     "BigAutoField": "bigint identity(1, 1)",
-    "DateTimeField": "timestamp",
     "TextField": "varchar(max)",  # text must be varchar(max)
     "UUIDField": "varchar(32)",  # redshift doesn't support uuid fields
 }
@@ -526,25 +525,6 @@ class DatabaseWrapper(BasePGDatabaseWrapper):
         self.creation = DatabaseCreation(self)
         self.introspection = DatabaseIntrospection(self)
         self.validation = BaseDatabaseValidation(self)
-
-    def init_connection_state(self):
-        self.connection.set_client_encoding('UTF8')
-
-        tz = self.settings_dict['TIME_ZONE']
-        conn_tz = self.connection.get_parameter_status('TimeZone')
-
-        if tz and conn_tz != tz:
-            logger.debug("TIME_ZONE `%s` is specified and redshift is using `%s`. "
-                         "However, Redshift doesn't support `SET TIME ZONE` command, "
-                         "so redshift backend do nothing.", tz, conn_tz)
-            cursor = self.connection.cursor()
-            try:
-                cursor.execute('SELECT version()')
-            finally:
-                cursor.close()
-            # Commit after setting the time zone (see #17062)
-            if not self.get_autocommit():
-                self.connection.commit()
 
     def check_constraints(self, table_names=None):
         """

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -528,6 +528,6 @@ class DatabaseWrapper(BasePGDatabaseWrapper):
 
     def check_constraints(self, table_names=None):
         """
-        No constraints to check in Redsfhift.
+        No constraints to check in Redshift.
         """
         pass

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -25,7 +25,7 @@ class DatabaseWrapperTest(unittest.TestCase):
 expected_ddl_normal = norm_sql(
     u'''CREATE TABLE "testapp_testmodel" (
     "id" integer identity(1, 1) NOT NULL PRIMARY KEY,
-    "ctime" timestamp NOT NULL,
+    "ctime" timestamp with time zone NOT NULL,
     "text" varchar(max) NOT NULL,
     "uuid" varchar(32) NOT NULL
 )
@@ -36,7 +36,7 @@ expected_ddl_meta_keys = norm_sql(
     "id" integer identity(1, 1) NOT NULL PRIMARY KEY,
     "name" varchar(100) NOT NULL,
     "age" integer NOT NULL,
-    "created_at" timestamp NOT NULL
+    "created_at" timestamp with time zone NOT NULL
 ) SORTKEY(created_at)
 ;''')
 


### PR DESCRIPTION
See: [Amazon Redshift introduces new data type to support time zones in time stamps](https://aws.amazon.com/jp/about-aws/whats-new/2016/09/amazon-redshift-introduces-new-data-type-to-support-time-zones-in-time-stamps/)

So,

- Redshift can set time zone to session using [`SET TIMEZONE`](https://docs.aws.amazon.com/redshift/latest/dg/r_timezone_config.html)
- And can create table with [`TIMESTAMP WITH TIME ZONE`](http://docs.aws.amazon.com/redshift/latest/dg/r_Datetime_types.html) fields