### PR TITLE
Add UUIDField support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ Type mapping:
 * 'bigint identity(1, 1)' for BigAutoField
 * 'timestamp' for DateTimeField
 * 'varchar(max)' for TextField
+* 'varchar(32)' for UUIDField
 * Possibility to multiply VARCHAR length to support utf-8 string, using
   `REDSHIFT_VARCHAR_LENGTH_MULTIPLIER` setting.
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -183,7 +183,6 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
                 if autoinc_sql:
                     self.deferred_sql.extend(autoinc_sql)
 
-
         # see https://github.com/django/django/commit/01ec127bae
         if DJANGO_VERSION < (1, 9):  # for django-1.8
             # Add any unique_togethers

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -463,6 +463,7 @@ redshift_data_types = {
     "BigAutoField": "bigint identity(1, 1)",
     "DateTimeField": "timestamp",
     "TextField": "varchar(max)",  # text must be varchar(max)
+    "UUIDField": "varchar(32)",  # redshift doesn't support uuid fields
 }
 
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -123,12 +123,6 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
     def _create_index_sql(self, model, fields, suffix="", sql=None):
         raise NotImplementedError("Redshift doesn't support INDEX")
 
-    def add_index(self, model, index):
-        pass
-
-    def remove_index(self, model, index):
-        pass
-
     def create_model(self, model):
         """
         Takes a model and creates a table for it in the database.

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -126,7 +126,6 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
     def remove_index(self, model, index):
         pass
 
-
     def create_model(self, model):
         """
         Takes a model and creates a table for it in the database.

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -120,6 +120,13 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
     def _create_index_sql(self, model, fields, suffix="", sql=None):
         raise NotImplementedError("Redshift doesn't support INDEX")
 
+    def add_index(self, model, index):
+        pass
+
+    def remove_index(self, model, index):
+        pass
+
+
     def create_model(self, model):
         """
         Takes a model and creates a table for it in the database.

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -26,7 +26,8 @@ expected_ddl = norm_sql(
     u'''CREATE TABLE "testapp_testmodel" (
     "id" integer identity(1, 1) NOT NULL PRIMARY KEY,
     "ctime" timestamp NOT NULL,
-    "text" varchar(max) NOT NULL
+    "text" varchar(max) NOT NULL,
+    "uuid" varchar(32) NOT NULL
 )
 ;''')
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from django.db.models import Model
-from django.db.models import AutoField, DateTimeField, TextField
+from django.db.models import AutoField, DateTimeField, TextField, UUIDField
 
 
 class TestModel(Model):
     ctime = DateTimeField()
     text = TextField()
+    uuid = UUIDField()


### PR DESCRIPTION
Since redshift doesn't have native uuid support, we do similar stuff as the sqlite3 backend does.

Also, add backwards compatable way of creating tables with unique_together since that was changed in django 1.9.