### PR TITLE
Fix wrong SQL syntax for SORTKEY

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -501,7 +501,7 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
         """
         if not model._meta.ordering:
             return ""
-        normilized_fields = [field.strip('-') for field in model._meta.ordering]
+        normilized_fields = [self.connection.ops.quote_name(field.strip('-')) for field in model._meta.ordering]
         return " SORTKEY({fields})".format(fields=', '.join(normilized_fields))
 
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -501,7 +501,10 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
         """
         if not model._meta.ordering:
             return ""
-        normilized_fields = [self.connection.ops.quote_name(field.strip('-')) for field in model._meta.ordering]
+        normilized_fields = [
+            self.connection.ops.quote_name(field.strip('-'))
+            for field in model._meta.ordering
+        ]
         return " SORTKEY({fields})".format(fields=', '.join(normilized_fields))
 
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -499,11 +499,10 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
         N.B.: no validation is made on this option, we'll let the Database
               do the validation for us.
         """
-        options = ['SORTKEY({})'.format(field) for field in model._meta.ordering]
-        if options:
-            return " " + " ".join(options)
-
-        return ""
+        if not model._meta.ordering:
+            return ""
+        normilized_fields = [field.strip('-') for field in model._meta.ordering]
+        return " SORTKEY({fields})".format(fields=', '.join(normilized_fields))
 
 
 redshift_data_types = {

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -37,7 +37,7 @@ expected_ddl_meta_keys = norm_sql(
     "name" varchar(100) NOT NULL,
     "age" integer NOT NULL,
     "created_at" timestamp with time zone NOT NULL
-) SORTKEY(created_at)
+) SORTKEY(created_at, id)
 ;''')
 
 

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -37,7 +37,7 @@ expected_ddl_meta_keys = norm_sql(
     "name" varchar(100) NOT NULL,
     "age" integer NOT NULL,
     "created_at" timestamp with time zone NOT NULL
-) SORTKEY(created_at, id)
+) SORTKEY("created_at", "id")
 ;''')
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -15,4 +15,4 @@ class TestModelWithMetaKeys(models.Model):
     created_at = models.DateTimeField()
 
     class Meta:
-        ordering = ['created_at']
+        ordering = ['created_at', '-id']


### PR DESCRIPTION
#20 occured syntax error if specify multiple column as SORTKEY.

See: http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html