### PR TITLE
Support django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ python:
   - 3.5
   - 3.6
 env:
-  - DJANGO_VERSION=1.8.*
-  - DJANGO_VERSION=1.9.*
   - DJANGO_VERSION=1.10.*
   - DJANGO_VERSION=1.11.*
+  - DJANGO_VERSION=2.0.*
+matrix:
+  exclude:
+  - python: 2.7
+    env: DJANGO_VERSION=2.0.*
 install:
   - pip install -U pip wheel
   - pip install -U setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   - python: 2.7
     env: DJANGO_VERSION=2.0.*
 install:
-  - pip install -U pip wheel
+  - pip install -U pip==9.0.* wheel
   - pip install -U setuptools
   - pip install django==$DJANGO_VERSION
   - pip install -U -r test-requires.txt

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Redshift database backend for Django
 This product is tested with:
 
 * python-2.7, 3.5, 3.6
-* django-1.11
+* django-1.11,2.0
 
 Differences from postgres_psycopg2 backend
 ==========================================

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,7 @@ Redshift database backend for Django
 This product is tested with:
 
 * python-2.7, 3.5, 3.6
-* django-1.8, 1.9, 1.10, 1.11
-
+* django-1.11
 
 Differences from postgres_psycopg2 backend
 ==========================================
@@ -54,7 +53,6 @@ In some case, MAX(pk) workaround does not work correctly.
 Bulk insertion makes non-contiguous IDs like: 1, 4, 7, 10, ...
 and single insertion after such bulk insertion generates strange id value like 2 (smallest non-used id).
 
-
 SETTINGS
 ========
 
@@ -98,11 +96,9 @@ Testing this package requires:
 
 and `wheelhouse` directory contains psycopg2 manylinux1 wheels for using in each tests.
 
-
 LICENSE
 =======
 Apache Software License
-
 
 CHANGES
 =======
@@ -135,11 +131,9 @@ Bug Fixes:
   of 'sql_create_table_unique'.
 * #27: annotate() does not work on Django-1.9 and later. Thanks to Takayuki Hirai.
 
-
 Documentation:
 
 * Add documentation: http://django-redshift-backend.rtfd.io/
-
 
 0.7 (2017-06-08)
 ----------------
@@ -178,7 +172,6 @@ Documentation:
 * More compat with redshift: add TextField
 * More compat with redshift: not use DEFERRABLE, CONSTRAINT, DROP DEFAULT
 * More compat with redshift: support modify column
-
 
 0.2.1 (2016-02-01)
 ------------------

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -11,13 +11,7 @@ import uuid
 import logging
 
 from django.conf import settings
-from django import VERSION as DJANGO_VERSION
-try:
-    # Need for Django v1.11+
-    from django.db.backends.base.validation import BaseDatabaseValidation
-except ImportError:
-    # Need for older versions of Django < v1.11
-    from django.db.backends.postgresql_psycopg2.base import BaseDatabaseValidation
+from django.db.backends.base.validation import BaseDatabaseValidation
 from django.db.backends.postgresql_psycopg2.base import (
     DatabaseFeatures as BasePGDatabaseFeatures,
     DatabaseWrapper as BasePGDatabaseWrapper,
@@ -27,6 +21,7 @@ from django.db.backends.postgresql_psycopg2.base import (
     DatabaseCreation as BasePGDatabaseCreation,
     DatabaseIntrospection,
 )
+
 
 logger = logging.getLogger('django.db.backends')
 
@@ -188,20 +183,11 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
                 if autoinc_sql:
                     self.deferred_sql.extend(autoinc_sql)
 
-        # see https://github.com/django/django/commit/01ec127bae
-        if DJANGO_VERSION < (1, 9):  # for django-1.8
-            # Add any unique_togethers
-            for fields in model._meta.unique_together:
-                columns = [model._meta.get_field(field).column for field in fields]
-                column_sqls.append(self.sql_create_table_unique % {
-                    "columns": ", ".join(self.quote_name(column) for column in columns),
-                })
-        else:  # for django-1.9 or later
-            # Add any unique_togethers (always deferred, as some fields might
-            # be created afterwards, like geometry fields with some backends)
-            for fields in model._meta.unique_together:
-                columns = [model._meta.get_field(field).column for field in fields]
-                self.deferred_sql.append(self._create_unique_sql(model, columns))
+        # Add any unique_togethers (always deferred, as some fields might
+        # be created afterwards, like geometry fields with some backends)
+        for fields in model._meta.unique_together:
+            columns = [model._meta.get_field(field).column for field in fields]
+            self.deferred_sql.append(self._create_unique_sql(model, columns))
 
         # Make the table
         sql = self.sql_create_table % {

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -160,9 +160,10 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
                 definition += " %s" % col_type_suffix
             params.extend(extra_params)
             # FK
-            if field.rel and field.db_constraint:
-                to_table = field.rel.to._meta.db_table
-                to_column = field.rel.to._meta.get_field(field.rel.field_name).column
+            if field.remote_field and field.db_constraint:
+                to_table = field.remote_field.to._meta.db_table
+                to_column = field.remote_field.to._meta.get_field(
+                    field.remote_field.field_name).column
                 if self.connection.features.supports_foreign_keys:
                     self.deferred_sql.append(self._create_fk_sql(
                         model, field, "_fk_%(to_table)s_%(to_column)s"))
@@ -209,8 +210,8 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
 
         # Make M2M tables
         for field in model._meta.local_many_to_many:
-            if field.rel.through._meta.auto_created:
-                self.create_model(field.rel.through)
+            if field.remote_field.through._meta.auto_created:
+                self.create_model(field.remote_field.through)
 
     def add_field(self, model, field):
         """
@@ -219,8 +220,8 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
         table instead (for M2M fields)
         """
         # Special-case implicit M2M tables
-        if field.many_to_many and field.rel.through._meta.auto_created:
-            return self.create_model(field.rel.through)
+        if field.many_to_many and field.remote_field.through._meta.auto_created:
+            return self.create_model(field.remote_field.through)
 
         # Get the column's definition
         # ## To add column to existent table on Redshift, field.null must be allowed
@@ -248,7 +249,7 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
         # ## Redshift doesn't support INDEX.
 
         # Add any FK constraints later
-        if (field.rel and
+        if (field.remote_field and
                 self.connection.features.supports_foreign_keys and
                 field.db_constraint):
             self.deferred_sql.append(
@@ -263,7 +264,7 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
 
         # Drop any FK constraints, we'll remake them later
         fks_dropped = set()
-        if old_field.rel and old_field.db_constraint:
+        if old_field.remote_field and old_field.db_constraint:
             fk_names = self._constraint_names(model, [old_field.column], foreign_key=True)
             if strict and len(fk_names) != 1:
                 raise ValueError(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requires = [
-    'django',
+    'Django>=1.11',
     'psycopg2',
 ]
 
@@ -32,9 +32,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'Environment :: Plugins',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'Environment :: Plugins',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -1,7 +1,6 @@
 -f./wheelhouse
 psycopg2==2.5.5
 pytest
-mock
 docutils<0.13  # 0.13 + py27 cause 'setup.py check' error. see: https://bugs.python.org/issue23063
 flake8
 -e.

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -2,7 +2,6 @@
 
 import unittest
 
-import django
 from django.db import connections
 from django.core.management.color import no_style
 import pytest
@@ -56,18 +55,11 @@ expected_dml_annotate = norm_sql(
 
 
 class ModelTest(unittest.TestCase):
-
     def check_model_creation(self, model, expected_ddl):
         conn = connections['default']
         statements, params = conn.creation.sql_create_model(model, no_style(), set())
         sql = norm_sql(''.join(statements))
         self.assertEqual(sql, expected_ddl)
-
-    @pytest.mark.skipif(django.VERSION >= (1, 9),
-                        reason="Django-1.9 or later doesn't support sql creation")
-    def test_create_table(self):
-        from testapp.models import TestModel
-        self.check_model_creation(TestModel, expected_ddl_normal)
 
     def test_annotate(self):
         from django.db.models import Count
@@ -79,7 +71,6 @@ class ModelTest(unittest.TestCase):
 
 
 class MigrationTest(unittest.TestCase):
-
     def check_model_creation(self, model, expected_ddl):
         conn = connections['default']
         schema_editor = conn.schema_editor(collect_sql=True)
@@ -88,14 +79,10 @@ class MigrationTest(unittest.TestCase):
         sql = norm_sql(''.join(schema_editor.collected_sql))
         self.assertEqual(sql, expected_ddl)
 
-    @pytest.mark.skipif(django.VERSION < (1, 8),
-                        reason="Django-1.8 or earlier doesn't support migration")
     def test_create_model(self):
         from testapp.models import TestModel
         self.check_model_creation(TestModel, expected_ddl_normal)
 
-    @pytest.mark.skipif(django.VERSION < (1, 8),
-                        reason="Django-1.8 or earlier doesn't support migration")
     def test_create_table_meta_keys(self):
         from testapp.models import TestModelWithMetaKeys
         self.check_model_creation(TestModelWithMetaKeys, expected_ddl_meta_keys)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -23,5 +23,5 @@ class TestParentModel(models.Model):
 
 
 class TestChildModel(models.Model):
-    parent = models.ForeignKey(TestParentModel)
+    parent = models.ForeignKey(TestParentModel, on_delete=models.CASCADE)
     age = models.IntegerField()


### PR DESCRIPTION
- Support django 2.0 and add tests
- Remove EOL versions (1.8, 1.9, 1.10 - [roadmap](https://www.djangoproject.com/weblog/2015/jun/25/roadmap/))
- Run only supported python versions for each django versions ([doc](https://docs.djangoproject.com/en/2.0/faq/install/#what-python-version-can-i-use-with-django))
- Use tox for testing (flake8, readme tests are run only once)
- Cache wheels in travis cache mechanism