### PR TITLE
Drop EOL version supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ python:
   - 3.5
   - 3.6
 env:
-  - DJANGO_VERSION=1.8.*
-  - DJANGO_VERSION=1.9.*
-  - DJANGO_VERSION=1.10.*
   - DJANGO_VERSION=1.11.*
 install:
   - pip install -U pip

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Redshift database backend for Django
 This product is tested with:
 
 * python-2.7, 3.5, 3.6
-* django-1.8, 1.9, 1.10, 1.11
+* django-1.11
 
 
 Differences from postgres_psycopg2 backend
@@ -96,9 +96,6 @@ Testing this package requires:
 * virtualenv-15.0.1 or later
 * pip-8.1.1 or later
 
-and `wheelhouse` directory contains psycopg2 manylinux1 wheels for using in each tests.
-
-
 LICENSE
 =======
 Apache Software License
@@ -110,6 +107,7 @@ CHANGES
 0.9 (Unreleased)
 ----------------
 
+* Drop support for Django 1.8, 1.9 and 1.10
 
 0.8 (2018-06-01)
 ----------------

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -2,10 +2,8 @@
 
 import unittest
 
-import django
 from django.db import connections
 from django.core.management.color import no_style
-import pytest
 
 
 def norm_sql(sql):
@@ -63,12 +61,6 @@ class ModelTest(unittest.TestCase):
         sql = norm_sql(''.join(statements))
         self.assertEqual(sql, expected_ddl)
 
-    @pytest.mark.skipif(django.VERSION >= (1, 9),
-                        reason="Django-1.9 or later doesn't support sql creation")
-    def test_create_table(self):
-        from testapp.models import TestModel
-        self.check_model_creation(TestModel, expected_ddl_normal)
-
     def test_annotate(self):
         from django.db.models import Count
         from testapp.models import TestParentModel
@@ -88,14 +80,10 @@ class MigrationTest(unittest.TestCase):
         sql = norm_sql(''.join(schema_editor.collected_sql))
         self.assertEqual(sql, expected_ddl)
 
-    @pytest.mark.skipif(django.VERSION < (1, 8),
-                        reason="Django-1.8 or earlier doesn't support migration")
     def test_create_model(self):
         from testapp.models import TestModel
         self.check_model_creation(TestModel, expected_ddl_normal)
 
-    @pytest.mark.skipif(django.VERSION < (1, 8),
-                        reason="Django-1.8 or earlier doesn't support migration")
     def test_create_table_meta_keys(self):
         from testapp.models import TestModelWithMetaKeys
         self.check_model_creation(TestModelWithMetaKeys, expected_ddl_meta_keys)


### PR DESCRIPTION
Subject: Drop following EOL version supports

### Feature or Bugfix

- Feature

### Purpose

- Split a #29 PR

### Detail

Following versions are EOL

- 1.8
- 1.9
- 1.10

### Relates

- https://www.djangoproject.com/download/


