### PR TITLE
Fix use of super() to be python 2 compatible.

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -71,7 +71,7 @@ class DatabaseOperations(BasePGDatabaseOperations):
         return []
 
     def get_db_converters(self, expression):
-        converters = super().get_db_converters(expression)
+        converters = super(DatabaseOperations, self).get_db_converters(expression)
         internal_type = expression.output_field.get_internal_type()
         if internal_type == 'UUIDField':
             converters.append(self.convert_uuidfield_value)


### PR DESCRIPTION
Subject: Fix use of super() to be python 2 compatible.

### Feature or Bugfix
- Bugfix

### Purpose
- There was a naked `super()` call which is an error on python 2. This change replaces it with the verbose `super(<clsname>, self)` call, which works on both python 2 and python 3.


