### PR TITLE
Add support for distkey.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ dist/
 .venv
 .cache
 .tox
-
+.pytest_cache/

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Using distkey
 ---------------------------------
 
 There is built-in support for this option for Django >= 1.11. To use `distkey`, define an index on the model
-meta with the custom index type `django_redshift_backend.base.DistKey` with `fields` naming a single field::
+meta with the custom index type `django_redshift_backend.distkey.DistKey` with `fields` naming a single field::
 
   class MyModel(models.Model):
       ...
@@ -128,7 +128,7 @@ That is, to go from::
        ...
        migrations.AddIndex(
             model_name='facttable',
-            index=django_redshift_backend.base.DistKey(fields=['distkeycol'], name='...'),
+            index=django_redshift_backend.distkey.DistKey(fields=['distkeycol'], name='...'),
         ),
     ]
 
@@ -145,7 +145,7 @@ To::
                 ...
             ],
             options={
-                'indexes': [django_redshift_backend.base.DistKey(fields=['distkeycol'], name='...')],
+                'indexes': [django_redshift_backend.distkey.DistKey(fields=['distkeycol'], name='...')],
             },
         ),
        ...

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,137 @@ There is built-in support for this option for Django >= 1.9. To use `sortkey`, s
 
 N.B.: there is no validation of this option, instead we let Redshift validate it for you. Be sure to refer to the `documentation <http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_examples.html>`_.
 
+Using distkey
+---------------------------------
+
+There is built-in support for this option for Django >= 1.11. To use `distkey`, define an index on the model
+meta with the custom index type `django_redshift_backend.base.DistKey` with `fields` naming a single field::
+
+  class MyModel(models.Model):
+      ...
+
+      class Meta:
+          indexes = [DistKey(fields=['customer_id'])]
+
+Redshift doesn't have conventional indexes, and we don't generate SQL for them. We merely use
+`indexes` as a convenient place in the Meta to identify the `distkey`.
+
+You will likely encounter the following complication:
+
+Inlining Index Migrations
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Django's `makemigrations` generates a migration file that first applies a `CreateModel` operation without the
+`indexes` option, and then adds the index in a separate `AddIndex` operation.
+
+However Redshift requires that the `distkey` be specified at table creation. As a result, you may need to
+manually edit your migration files to move the index creation into the initial `CreateModel`.
+
+That is, to go from::
+
+    operations = [
+        ...
+        migrations.CreateModel(
+            name='FactTable',
+            fields=[
+                ('distkeycol', models.CharField()),
+                ('measure1', models.IntegerField()),
+                ('measure2', models.IntegerField())
+                ...
+            ]
+        ),
+       ...
+       migrations.AddIndex(
+            model_name='facttable',
+            index=django_redshift_backend.base.DistKey(fields=['distkeycol'], name='...'),
+        ),
+    ]
+
+To::
+
+    operations = [
+        ...
+        migrations.CreateModel(
+            name='FactTable',
+            fields=[
+                ('distkeycol', models.CharField()),
+                ('measure1', models.IntegerField()),
+                ('measure2', models.IntegerField())
+                ...
+            ],
+            options={
+                'indexes': [django_redshift_backend.base.DistKey(fields=['distkeycol'], name='...')],
+            },
+        ),
+       ...
+    ]
+
+
+Inlining ForeignKey Migrations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It is common to distribute fact tables on a foreign key column referencing the primary key of a dimension table.
+
+In this case you may also encounter the following added complication:
+
+Django's `makemigrations` generates a migration file that first applies a `CreateModel` operation without the
+`ForeignKey` column, and then adds the `ForeignKey` column in a separate `AddField` operation.  It does this to
+avoid attempts to create foreign key constraints against tables that haven't been created yet.
+
+However Redshift requires that the `distkey` be specified at table creation. As a result, you may need to
+manually edit your migration files to move the ForeignKey column into the initial `CreateModel`, while also
+ensuring that the referenced table appears *before* the referencing table in the file.
+
+That is, to go from::
+
+    operations = [
+        ...
+        migrations.CreateModel(
+            name='FactTable',
+            fields=[
+                ('measure1', models.IntegerField()),
+                ('measure2', models.IntegerField())
+                ...
+            ]
+        ),
+       ...
+       migrations.CreateModel(
+            name='Dimension1Table',
+            fields=[
+                ...
+            ]
+        ),
+        ...
+        migrations.AddField(
+            model_name='facttable',
+            name='dim1',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='myapp.Dimension1Table'),
+        ),
+        ...
+    ]
+
+To::
+
+    operations = [
+       migrations.CreateModel(
+            name='Dimension1Table',
+            fields=[
+                ...
+            ]
+        ),
+        ...
+        migrations.CreateModel(
+            name='FactTable',
+            fields=[
+                ('measure1', models.IntegerField()),
+                ('measure2', models.IntegerField()),
+                ('dim1', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='myapp.Dimension1Table'))
+                ...
+            ]
+        ),
+        ...
+    ]
+
+
+
 TESTING
 =======
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -22,7 +22,9 @@ from django.db.backends.postgresql_psycopg2.base import (
     DatabaseCreation as BasePGDatabaseCreation,
     DatabaseIntrospection,
 )
-from django.db.models import Index
+
+from django_redshift_backend.distkey import DistKey
+
 
 logger = logging.getLogger('django.db.backends')
 
@@ -105,10 +107,6 @@ def _related_non_m2m_objects(old_field, new_field):
          for obj in new_field.model._meta.related_objects
          if not obj.field.many_to_many)
     )
-
-
-class DistKey(Index):
-    pass
 
 
 class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
@@ -496,12 +494,14 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
               do the validation for us.
         """
         def quoted_column_name(field_name):
-            # We strip the '-' that may precede the field name in an `ordering` specification.
+            # We strip the '-' that may precede the field name in an `ordering`
+            # specification.
             try:
-              colname = model._meta.get_field(field_name.strip('-')).get_attname_column()[1]
+                colname = model._meta.get_field(
+                    field_name.strip('-')).get_attname_column()[1]
             except FieldDoesNotExist:
-                # Out of an abundance of caution - e.g., so that you get a more appropriate
-                # error message higher up the stack.
+                # Out of an abundance of caution - e.g., so that you get a more
+                # appropriate error message higher up the stack.
                 colname = field_name
             return self.connection.ops.quote_name(colname)
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -11,6 +11,7 @@ import uuid
 import logging
 
 from django.conf import settings
+from django.core.exceptions import FieldDoesNotExist
 from django.db.backends.base.validation import BaseDatabaseValidation
 from django.db.backends.postgresql_psycopg2.base import (
     DatabaseFeatures as BasePGDatabaseFeatures,
@@ -496,7 +497,12 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
         """
         def quoted_column_name(field_name):
             # We strip the '-' that may precede the field name in an `ordering` specification.
-            colname = model._meta.get_field(field_name.strip('-')).get_attname_column()[1]
+            try:
+              colname = model._meta.get_field(field_name.strip('-')).get_attname_column()[1]
+            except FieldDoesNotExist:
+                # Out of an abundance of caution - e.g., so that you get a more appropriate
+                # error message higher up the stack.
+                colname = field_name
             return self.connection.ops.quote_name(colname)
 
         create_options = []

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -21,6 +21,7 @@ from django.db.backends.postgresql_psycopg2.base import (
     DatabaseCreation as BasePGDatabaseCreation,
     DatabaseIntrospection,
 )
+from django.db.models import Index
 
 logger = logging.getLogger('django.db.backends')
 
@@ -105,9 +106,13 @@ def _related_non_m2m_objects(old_field, new_field):
     )
 
 
+class DistKey(Index):
+    pass
+
+
 class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
 
-    sql_create_table = "CREATE TABLE %(table)s (%(definition)s)%(options)s"
+    sql_create_table = "CREATE TABLE %(table)s (%(definition)s) %(options)s"
 
     @property
     def multiply_varchar_length(self):
@@ -483,18 +488,46 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
     def _get_create_options(self, model):
         """
         Provide options to create the table. Supports:
+            - distkey
             - sortkey
 
-        N.B.: no validation is made on this option, we'll let the Database
+        N.B.: no validation is made on these options, we'll let the Database
               do the validation for us.
         """
-        if not model._meta.ordering:
-            return ""
-        normilized_fields = [
-            self.connection.ops.quote_name(field.strip('-'))
-            for field in model._meta.ordering
-        ]
-        return " SORTKEY({fields})".format(fields=', '.join(normilized_fields))
+        def quoted_column_name(field_name):
+            # We strip the '-' that may precede the field name in an `ordering` specification.
+            colname = model._meta.get_field(field_name.strip('-')).get_attname_column()[1]
+            return self.connection.ops.quote_name(colname)
+
+        create_options = []
+
+        distkey = None
+        for idx in model._meta.indexes:
+            if isinstance(idx, DistKey):
+                if distkey:
+                    raise ValueError("Model {} has more than one DistKey.".format(
+                        model.__name__))
+                distkey = idx
+        if distkey:
+            # It would be nicer to enforce this by having DistKey's ctor accept exactly
+            # one field. However overriding the superclass Index ctor causes problems
+            # with migrations, so we validate here instead.
+            if len(distkey.fields) != 1:
+                raise ValueError('DistKey on model {} must have exactly '
+                                 'one field.'.format(model.__name__))
+            normalized_field = quoted_column_name(distkey.fields[0])
+            create_options.append("DISTKEY({})".format(normalized_field))
+            # TODO: Support DISTSTYLE ALL.
+
+        if model._meta.ordering:
+            normalized_fields = [
+                quoted_column_name(field)
+                for field in model._meta.ordering
+            ]
+            create_options.append("SORTKEY({fields})".format(
+                fields=', '.join(normalized_fields)))
+
+        return " ".join(create_options)
 
 
 redshift_data_types = {

--- a/django_redshift_backend/distkey.py
+++ b/django_redshift_backend/distkey.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from django.db.models import Index
+
+
+class DistKey(Index):
+    """A single-field index denoting the distkey for a model.
+
+    Use as follows:
+
+      class MyModel(models.Model):
+      ...
+
+      class Meta:
+          indexes = [DistKey(fields=['customer_id'])]
+    """
+    pass

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -34,8 +34,9 @@ expected_ddl_meta_keys = norm_sql(
     "id" integer identity(1, 1) NOT NULL PRIMARY KEY,
     "name" varchar(100) NOT NULL,
     "age" integer NOT NULL,
-    "created_at" timestamp with time zone NOT NULL
-) SORTKEY("created_at", "id")
+    "created_at" timestamp with time zone NOT NULL,
+    "fk_id" integer NOT NULL
+) DISTKEY("fk_id") SORTKEY("created_at", "id")
 ;''')
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -2,6 +2,8 @@
 
 from django.db import models
 
+from django_redshift_backend.base import DistKey
+
 
 class TestModel(models.Model):
     ctime = models.DateTimeField()
@@ -9,12 +11,18 @@ class TestModel(models.Model):
     uuid = models.UUIDField()
 
 
+class TestReferencedModel(models.Model):
+    id = models.IntegerField()
+
+
 class TestModelWithMetaKeys(models.Model):
     name = models.CharField(max_length=100)
     age = models.IntegerField()
     created_at = models.DateTimeField()
+    fk = models.ForeignKey(TestReferencedModel)
 
     class Meta:
+        indexes = [DistKey(fields=['fk'])]
         ordering = ['created_at', '-id']
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -19,7 +19,7 @@ class TestModelWithMetaKeys(models.Model):
     name = models.CharField(max_length=100)
     age = models.IntegerField()
     created_at = models.DateTimeField()
-    fk = models.ForeignKey(TestReferencedModel)
+    fk = models.ForeignKey(TestReferencedModel, on_delete=models.CASCADE)
 
     class Meta:
         indexes = [DistKey(fields=['fk'])]


### PR DESCRIPTION
Subject: Add support for setting a DISTKEY.

### Feature or Bugfix
- Feature

### Purpose
Setting a DISTKEY is a basic requirement in real-world Redshift clusters. 
This change adds support for designating a column as the DISTKEY.
There are some complications and caveats, explained in the README.


### Detail
This is implemented by setting a custom index type in the model's meta class:

```
from django_redshift_backend.base import DistKey
...
class Fact(Model):
  class Meta:
    indexes = [DistKey(fields=['dim1'])]

  dim1 = ForeignKey(Dimension1Model)
```

But, as explained in the README, this will likely require some hand-editing
of the migration files, so that all necessary information is available at 
table creation time.

This change also fixes a minor issue with the SORTKEY support, where
it was assumed that the db column name was the same as the field name.
But this is not the case, e.g., for ForeignKey fields.

This change also replaces references to the defunct `remote_field.to` with
the `remote_field.related_model`.

### Relates
https://github.com/shimizukawa/django-redshift-backend/issues/16
https://github.com/shimizukawa/django-redshift-backend/pull/20

