### PR TITLE
Rename to 'remote_field' from 'to'

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -160,8 +160,8 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
             params.extend(extra_params)
             # FK
             if field.remote_field and field.db_constraint:
-                to_table = field.remote_field.to._meta.db_table
-                to_column = field.remote_field.to._meta.get_field(
+                to_table = field.remote_field.related_model._meta.db_table
+                to_column = field.remote_field.related_model._meta.get_field(
                     field.remote_field.field_name).column
                 if self.connection.features.supports_foreign_keys:
                     self.deferred_sql.append(self._create_fk_sql(


### PR DESCRIPTION
Subject: Rename removed attributes at Django2.0

### Feature or Bugfix

- [ ] Feature
- [x] Bugfix

### Purpose

- Rename was omitted :(

### Detail

- `Field.remote_field.to` are removed too

### Relates

- https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0
